### PR TITLE
Refactor sendMail

### DIFF
--- a/src/features/ContactForm.tsx
+++ b/src/features/ContactForm.tsx
@@ -31,6 +31,8 @@ const ContactForm = () => {
   });
 
   const onSubmit: SubmitHandler<ContactSchema> = (data) => {
+    setErrorMessage("");
+    setSuccessMessage("");
     startTransition(async () => {
       try {
         const result = await sendMail({ ...data });
@@ -84,7 +86,11 @@ const ContactForm = () => {
       )}
 
       {successMessage && (
-        <span className="form-success w-full" role="alert" aria-live="assertive">
+        <span
+          className="form-success w-full"
+          role="alert"
+          aria-live="assertive"
+        >
           {successMessage}
         </span>
       )}

--- a/src/services/sendMail.ts
+++ b/src/services/sendMail.ts
@@ -1,6 +1,6 @@
 import type { SendMail } from "@/types";
 
-const API = (import.meta.env.VITE_API_URL || process.env.API_URL) as string;
+const API = import.meta.env.VITE_API_URL as string;
 
 const sendMail = async ({ name, email, subject, message }: SendMail) => {
   const response = await fetch(`${API}/api/send-email`, {

--- a/src/services/sendMail.ts
+++ b/src/services/sendMail.ts
@@ -3,22 +3,22 @@ import type { SendMail } from "@/types";
 const API = import.meta.env.VITE_API_URL as string;
 
 const sendMail = async ({ name, email, subject, message }: SendMail) => {
-  const response = await fetch(`${API}/api/send-email`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Accept: "application/json",
-    },
-    body: JSON.stringify({ name, email, subject, message }),
-  });
+  try {
+    const response = await fetch(`${API}/api/send-email`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify({ name, email, subject, message }),
+    });
 
-  if (!response.ok) {
-    throw new Error("Something went wrong. Please try again later.");
+    const result = await response.json();
+
+    return result;
+  } catch (error) {
+    throw Error((error as Error).message);
   }
-
-  const result = await response.json();
-
-  return result;
 };
 
 export default sendMail;

--- a/src/services/sendMail.ts
+++ b/src/services/sendMail.ts
@@ -17,7 +17,6 @@ const sendMail = async ({ name, email, subject, message }: SendMail) => {
 
     return result;
   } catch (error) {
-    console.log(error);
     throw Error((error as Error).message);
   }
 };

--- a/src/services/sendMail.ts
+++ b/src/services/sendMail.ts
@@ -17,6 +17,7 @@ const sendMail = async ({ name, email, subject, message }: SendMail) => {
 
     return result;
   } catch (error) {
+    console.log(error);
     throw Error((error as Error).message);
   }
 };


### PR DESCRIPTION
Refactor sendMail  to directly use VITE_API_URL from import.meta.env, removing fallback to process.env.